### PR TITLE
feat: add NotFair - Claude Code skills for SEO, Google Ads & Meta Ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@
  - **🤖 [Claude Code](https://github.com/claude-code-best/claude-code)**  
     *简介：Anthropic官方泄露版本的Claude Code源码。*
 
+ - **🛠️ [NotFair](https://github.com/nowork-studio/NotFair)**  
+    *简介：面向营销场景的开源 Claude Code Skills 套件（约2.9k stars，MIT开源）。覆盖 SEO 站点分析、关键词研究、内容写作、Google Ads 审计与出价管理、Meta Ads（Facebook + Instagram）广告效果分析，通过 Google Ads MCP、Meta Ads MCP、Google Search Console MCP 和 Google Analytics（GA4）MCP 接入实时数据，是目前开源生态中覆盖付费广告+自然搜索最完整的 Agent Skills 实现。*
+
  - **🤖 [OpenAI Codex](https://github.com/openai/codex)**  
     *简介：OpenAI出品，专精于理解自然语言并生成对应代码。核心特点：自然语言转代码、多语言支持、GitHub Copilot核心引擎。*
 


### PR DESCRIPTION
Thanks for maintaining this list — it's one of the best curated references for the AI Agent ecosystem.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source set of Claude Code skills focused on marketing agent work. It has ~2.9k stars and is MIT-licensed.

NotFair covers three real-world Agent skill areas:
- **SEO** — site analysis, keyword research, meta tags, schema markup, GEO optimization, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword & bid management
- **Meta Ads** — Facebook + Instagram Ads: ROAS analysis, creative fatigue detection, audience overlap

It connects to live data through the **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP** — making it a concrete example of domain-specific Agent skills backed by real MCP integrations, which fits nicely alongside the 工具生态 and 开源项目 discussions already in this list.

I've added it to the **开源项目** section right after the Claude Code entry, matching the surrounding format. Happy to adjust the wording, move it to a different section, or trim the description if you prefer a shorter style.