### PR TITLE
添加 Orkas 到开源项目

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,9 @@
     
   ## 开源项目
 
+ - **🖥️ [Orkas](https://github.com/Orkas-AI/Orkas)**  
+    *简介：开源、本地优先的多智能体桌面客户端，由 Commander 协调专业智能体并行或串行完成复杂任务，支持 macOS、Windows 与 Linux。*
+
  - **📈 [openclaw](https://github.com/openclaw/openclaw)**  
     *简介：OpenClaw开源项目。*
 


### PR DESCRIPTION
## 变更

在“开源项目”中加入 [Orkas](https://github.com/Orkas-AI/Orkas)，并沿用现有中文条目格式。

## 适配理由

Orkas 是 MIT 许可、持续维护的本地优先多智能体桌面客户端。它由 Commander 协调专业智能体并行或串行执行任务，符合本列表的 Agent 开源项目主题。

## 验证

- 已检索 README、历史 PR 和 Issue，未发现重复条目
- 项目仓库及官网当前均可访问
- 项目近期仍有提交和正式版本发布