### PR TITLE
添加 LWC 主动式 Agent 项目记忆

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@
 
     
   ## 开源项目
-  - **🧠 [LWC](https://github.com/JanYork/llm-wiki-cli)**  
+  - **🧠 [LWC](https://github.com/JanYork/llm-wiki-cli)**
     *简介：面向 AI 编程 Agent 的主动式项目记忆 CLI，支持跨会话、来源可追溯的 Wiki 记忆、SQLite/FTS5 全文检索、可选文档与代码图谱，并通过只读 MCP 接口向 Claude Code、Codex、Cursor、Gemini CLI、OpenCode 等 Agent 提供有边界的检索能力。*
 
   - **🤖 [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent)**  

--- a/README.md
+++ b/README.md
@@ -199,6 +199,9 @@
 
     
   ## 开源项目
+  - **🧠 [LWC](https://github.com/JanYork/llm-wiki-cli)**  
+    *简介：面向 AI 编程 Agent 的主动式项目记忆 CLI，支持跨会话、来源可追溯的 Wiki 记忆、SQLite/FTS5 全文检索、可选文档与代码图谱，并通过只读 MCP 接口向 Claude Code、Codex、Cursor、Gemini CLI、OpenCode 等 Agent 提供有边界的检索能力。*
+
   - **🤖 [prime-agent](https://github.com/PrimeIntellect-ai/prime-agent)**  
     *简介：A self-improving RLM agent for coding workflows and long-running autonomous tasks。*
     


### PR DESCRIPTION
## 内容

在“开源项目”中添加 LWC。LWC 是面向 AI 编程 Agent 的主动式项目记忆 CLI，提供跨会话、来源可追溯的 Wiki 记忆、SQLite/FTS5 检索、可选文档/代码图谱和只读 MCP 接口。

## 验证

- 仅修改 README.md
- 按现有条目格式新增 3 行
- 项目链接可访问
- `git diff --check` 通过