### PR TITLE
新增 OrcaReplay 到评估观测

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@
  - **🔗 [Open Agent Relay](https://github.com/ShakespeareLabs/open-agent-relay)**  
    *简介：开源、本地优先的 Agent 能力中继 CLI，可将 Claude Code、Codex 等本机 Agent 或自动化任务通过受信局域网暴露给其他 Agent 调用，同时让提示词、依赖、工作目录与凭据留在发布者设备上。*
 
+  - **🔬 [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) · [npm](https://www.npmjs.com/package/orcareplay)**
+    *简介：在进程与 socket 层记录 coding agent 的整场运行——模型请求、shell 命令的退出码、每轮文件变更、MCP 调用落在同一条时间线上。与只做观测的方案不同，它能把这次运行**重新跑一遍**：断网重放逐字节复现，或从任一检查点分叉到另一个模型，让两个模型面对完全相同的上下文与文件状态。Apache-2.0。*
 
 ## 评测基准
 


### PR DESCRIPTION
在 **评估观测** 下新增 OrcaReplay。

这一节现有条目（SigNoz 的 OTel 实践、opencode-plugin-otel、LangSmith/Langfuse/Phoenix 对比）都是**观测**——把一次运行看清楚。OrcaReplay 补的是另一半：**把它重新跑一遍**。

它在进程与 socket 层捕获，所以模型请求、每条 shell 命令及其退出码、每轮文件变更、MCP 调用落在同一条时间线上；之后断网重放（用录下的响应原样回放，逐字节复现，换台机器也一样），或从任一检查点分叉到另一个模型——两个模型面对完全相同的上下文和文件状态，对比才是干净的。

对这一节的读者可能有用的一点：它**不依赖 agent 配合**，也不需要接 SDK 或 OTel exporter。捕获在 base-URL 环境变量下面一层，所以连用 ChatGPT 订阅登录、只跟自己后端通信的 Codex CLI 也能录到。

按本节格式写（加粗标题 + 链接 + npm + 斜体简介）。Apache-2.0，`npm i -g orcareplay`，Node 20+。

一句实话：项目 2026-08-29 建库，150 star，还很新。
