### PR TITLE
Add the TaoLive report to Harness practice resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@
 - **📖 [横向拆解Claude Code、Codex等六大Agent上下文压缩策略后，我们做了第 7 个](https://mp.weixin.qq.com/s/BQwyvE2qIfguwKk63F3LZw)**  
   *简介：横向对比 Claude Code、Codex、OpenCode、Cline、Cursor、Amp 与 MemGPT/Letta 的上下文压缩策略，提炼分层渐进、成本递增、增量摘要、用户消息保护与单调边界等共识，并面向云端多用户 Agent 落地四级水位线（Snip / Prune / Summarize）方案，补充存储分离、跨轮缓存与多用户隔离等工程实践。*
 
+- **📖 [Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report](https://arxiv.org/abs/2608.15763)**<br>
+  *简介：淘天直播数字人 Agent 技术报告，介绍可独立更新的 Skills、Tools、Prompts 与 Hooks，以及通过 Harness-State Augmentation 改善模型对运行时变化的适应能力。*
+
 ## 感知记忆
 
 - **📖 [从架构到代码：深入理解 OpenClaw 的双源记忆系统](https://mp.weixin.qq.com/s/Ok3VwXft5fvvNWLBL6r2AA)**  


### PR DESCRIPTION
Thank you for collecting Chinese-language notes alongside the primary sources. The dedicated Harness practice section makes the systems material easy to find.

I'm Yuhan Sun, one of the authors of [Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report](https://arxiv.org/abs/2608.15763). This PR adds the report to **Harness 实践**.

The TaoLive report describes a production digital-avatar agent and the difficulty of keeping a domain-trained model responsive to harness changes. It includes the runtime architecture, Harness-State Augmentation, training stages, and held-out harness-edit experiments. The new entry follows the section's link-and-Chinese-summary format.

Thank you for considering the addition.

感谢整理这份中文 Agent 资源。报告与 Harness 实践栏目比较贴合：除了训练方法，也介绍直播数字人运行时中 Skills、工具和 Hooks 的组织方式。感谢审阅。
